### PR TITLE
Update Azure FQDN suffix regex

### DIFF
--- a/azure-plugin-config/azure-plugin.conf
+++ b/azure-plugin-config/azure-plugin.conf
@@ -81,7 +81,7 @@ instance {
   instance-prefix-regex: "^[a-z][a-z0-9-]{1,15}[a-z0-9]$"
 
   #
-  # Azure DNS FQDN suffix must be RFC 952 compliant
+  # Azure DNS FQDN suffix must be RFC 1123 compliant
   # Additional requirements:
   #   Linux host name cannot exceed 64 characters in length or contain the following characters:
   #   ` ~ ! @ # $ % ^ & * ( ) = + _ [ ] { } \ | ; : ' " , < > / ?
@@ -89,12 +89,19 @@ instance {
   #     can contain only lowercase letters, numbers, and hyphens
   #     the first character must be a letter
   #     the last character must be a letter or number
-  #     the value must be 3 or more characters long
+  #     the value must be 1 or more characters long
   # Cloudera is limiting the DNS name suffix to 38 characters:
   # 1 charater for the dot (.) that joins the DNS name suffix with the DNS label
-  # 37 characters for the user defined DNS FQDN suffix
+  # 37 characters for the user defined DNS FQDN suffix, including any dots (.)
   #
-  # This regex matches the user defined DNS FQDN suffix
+  # Here is the breakdown of the major sections of the regex:
+  #   "(?=.{1,37}$)": overall length must be between 1 and 37 inclusive
+  #   "(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*": match an alphanumeric or an alphanumeric,
+  #     followed by any number of alphanumeric and dashes, with the label ending in an
+  #     alphanumeric. This match is an optional match which is why it ends with a dot (.).
+  #   "([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])": the same matching as before without the requirement
+  #     of ending with a dot (.). If there's only one label then the regex only matches this last
+  #     section.
   #
-  dns-fqdn-suffix-regex: "^(?=.{3,37}$)([a-z][a-z0-9-]{1,35}[a-z0-9])(\\.[a-z][a-z0-9-]{1,35}[a-z0-9])*$"
+  dns-fqdn-suffix-regex: "^(?=.{1,37}$)(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$"
 }


### PR DESCRIPTION
Update Azure config with an updated FQDN suffix regex that relaxes dns label requirements.
