### PR TITLE
Improve parcel_provisioner.sh performance

### DIFF
--- a/preloaded-ami-builder/scripts/provisioning/parcel_provisioner.sh
+++ b/preloaded-ami-builder/scripts/provisioning/parcel_provisioner.sh
@@ -70,5 +70,5 @@ then
   echo "Done"
 fi
 
-echo "Sleeping for 300 seconds to ensure parcels will properly sync with EBS."
-sleep 300
+echo "Sync Linux volumes with EBS."
+sudo sync


### PR DESCRIPTION
In order to sync os buffers to disk, we can call the sync command:

https://linux.die.net/man/8/sync

which is both faster and deterministic.
