### PR TITLE
added HDFS Gateway role to gateway node definition (crucial!)

### DIFF
--- a/configs/aws.reference.conf
+++ b/configs/aws.reference.conf
@@ -1226,6 +1226,7 @@ cluster {
     }
 
     roles {
+      HDFS: [GATEWAY]
       HBASE: [GATEWAY]
       HIVE: [GATEWAY]
       SPARK_ON_YARN: [GATEWAY]


### PR DESCRIPTION
HDFS Gateway role is missing in the gateway node definition (crucial!) - aws.reference.conf