### PR TITLE
Enables Packer 1.2.5

### DIFF
--- a/faster-bootstrap/packer-json/rhel.json
+++ b/faster-bootstrap/packer-json/rhel.json
@@ -35,7 +35,7 @@
         "subnet_id": "{{user `subnet_id`}}",
         "security_group_id": "{{user `security_group_id`}}",
         "ssh_pty": "true",
-        "ssh_private_ip": "false",
+        "ssh_interface": "private_ip",
         "associate_public_ip_address": "{{user `associate_public_ip_address`}}"
     }],
     "provisioners": [


### PR DESCRIPTION
Packer 1.2.5 has removed support for the `ssh_private_ip` flag.

Here is the fix.