### PR TITLE
Fixes #57 - multiple nameservers returned by nslookup

### DIFF
--- a/azure-bootstrap-scripts/os-generic-bootstrap.sh
+++ b/azure-bootstrap-scripts/os-generic-bootstrap.sh
@@ -54,7 +54,7 @@ if [ "$reason" = BOUND ] || [ "$reason" = RENEW ] || [ "$reason" = REBIND ] || [
 then
     printf "\tnew_ip_address:%s\n" "${new_ip_address:?}"
     host=$(hostname -s)
-    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
     IFS='.' read -ra ipparts <<< "$new_ip_address"
     ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
     nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)
@@ -156,7 +156,7 @@ fi
 new_ip_address="$DHCP4_IP_ADDRESS"
 
 host=$(hostname -s)
-domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
 IFS='.' read -ra ipparts <<< "$new_ip_address"
 ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
 nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)

--- a/azure-dns-scripts/bootstrap_dns_dhclient.sh
+++ b/azure-dns-scripts/bootstrap_dns_dhclient.sh
@@ -35,7 +35,7 @@ if [ "$reason" = BOUND ] || [ "$reason" = RENEW ] || [ "$reason" = REBIND ] || [
 then
     printf "\tnew_ip_address:%s\n" "${new_ip_address:?}"
     host=$(hostname -s)
-    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
     IFS='.' read -ra ipparts <<< "$new_ip_address"
     ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
     nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)

--- a/azure-dns-scripts/bootstrap_dns_nm.sh
+++ b/azure-dns-scripts/bootstrap_dns_nm.sh
@@ -41,7 +41,7 @@ fi
 new_ip_address="$DHCP4_IP_ADDRESS"
 
 host=$(hostname -s)
-domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
 IFS='.' read -ra ipparts <<< "$new_ip_address"
 ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
 nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)

--- a/azure-dns-scripts/dhclient-exit-hooks
+++ b/azure-dns-scripts/dhclient-exit-hooks
@@ -28,7 +28,7 @@ if [ "$reason" = BOUND ] || [ "$reason" = RENEW ] ||
 then
     printf "\tnew_ip_address:%s\n" "${new_ip_address:?}"
     host=$(hostname -s)
-    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
     IFS='.' read -ra ipparts <<< "$new_ip_address"
     ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
     nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)

--- a/configs/azure-os-generic-bootstrap.conf
+++ b/configs/azure-os-generic-bootstrap.conf
@@ -96,7 +96,7 @@ if [ "$reason" = BOUND ] || [ "$reason" = RENEW ] || [ "$reason" = REBIND ] || [
 then
     printf "\tnew_ip_address:%s\n" "${new_ip_address:?}"
     host=$(hostname -s)
-    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
     IFS='.' read -ra ipparts <<< "$new_ip_address"
     ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
     nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)
@@ -198,7 +198,7 @@ fi
 new_ip_address="$DHCP4_IP_ADDRESS"
 
 host=$(hostname -s)
-domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
 IFS='.' read -ra ipparts <<< "$new_ip_address"
 ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
 nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)

--- a/sdx/sdx-azure-sample.conf
+++ b/sdx/sdx-azure-sample.conf
@@ -358,7 +358,7 @@ if [ "$reason" = BOUND ] || [ "$reason" = RENEW ] || [ "$reason" = REBIND ] || [
 then
     printf "\tnew_ip_address:%s\n" "${new_ip_address:?}"
     host=$(hostname -s)
-    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+    domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
     IFS='.' read -ra ipparts <<< "$new_ip_address"
     ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
     nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)
@@ -460,7 +460,7 @@ fi
 new_ip_address="$DHCP4_IP_ADDRESS"
 
 host=$(hostname -s)
-domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
+domain=$(nslookup $(grep -i nameserver /etc/resolv.conf | head -n 1 | cut -d ' ' -f 2) | grep -i name | cut -d ' ' -f 3 | cut -d '.' -f 2- | rev | cut -c 2- | rev)
 IFS='.' read -ra ipparts <<< "$new_ip_address"
 ptrrec="$(printf %s "$new_ip_address." | tac -s.)in-addr.arpa"
 nsupdatecmds=$(mktemp -t nsupdate.XXXXXXXXXX)


### PR DESCRIPTION
This minor change will fix a latent bug whereby nslookup could return a list of nameservers and the code would subsequently  break.

This is especially important to fix now that Altus can work with Cloud Providers whose DNS server is configured to accept multiple nameservers